### PR TITLE
Exit 2 on a partial failure of druzhba

### DIFF
--- a/druzhba/main.py
+++ b/druzhba/main.py
@@ -50,9 +50,8 @@ def process_database(
             )
         logger.info("Done with database %s", db_alias)
     except Exception as e:
-        # Catch everything except BaseExceptions like SystemExit,
-        # KeyboardInterrupt so we don't kill other DBs
         logger.exception("Fatal error in database %s, aborting", db_alias)
+        raise e
 
 
 def _process_database(
@@ -306,8 +305,13 @@ def run(args):
         # Preload _strptime to avoid a threading bug in cpython
         # See: https://mail.python.org/pipermail/python-list/2015-October/697689.html
         _ = datetime.datetime.strptime("2018-01-01 01:02:03", "%Y-%m-%d %H:%M:%S")
-        pool = Pool(args.num_processes)
-        pool.map(lambda db: process_database(*db), dbs)
+        with Pool(args.num_processes) as pool:
+            results = pool.map_async(lambda db: process_database(*db), dbs)
+
+            results.wait()
+            if not results.successful():
+                # Don't need to relog on failure, the process already logged
+                sys.exit(2)
 
     if args.validate_only:
         logger.info("Validation complete")


### PR DESCRIPTION
For https://gitlab.seatgeekadmin.com/data-science/data-science-issues/issues/5554

Test case:
```
import sys
from multiprocessing.dummy import Pool

def print_inverse(i):
    try:
        print(1 / i)
    except Exception as e:
        print(e)
        raise

with Pool(4) as pool:
    results = pool.map_async(print_inverse, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
    results.wait()
    if not results.successful():
        sys.exit(2)
```
```
/Users/samk/virtualenvs/druzhba/bin/python3.7 /Users/samk/Library/Preferences/IntelliJIdea2018.3/scratches/scratch_4.py
division by zero1.0
0.5
0.3333333333333333
0.25
0.2
0.16666666666666666
0.14285714285714285
0.125
0.1111111111111111

Process finished with exit code 2
```