### PR TITLE
Don't quote index column, it can be an expression

### DIFF
--- a/druzhba/mysql.py
+++ b/druzhba/mysql.py
@@ -201,7 +201,7 @@ class MySQLTableConfig(TableConfig):
         return "varchar({})".format(MysqlTypes.cmax)
 
     def _load_new_index_value(self):
-        query = 'SELECT MAX(`{}`) AS index_value FROM `{}`;'.format(
+        query = 'SELECT MAX({}) AS index_value FROM `{}`;'.format(
             self.index_column, self.source_table_name
         )
         return self.query_fetchone(query)["index_value"]

--- a/druzhba/postgres.py
+++ b/druzhba/postgres.py
@@ -103,7 +103,7 @@ class PostgreSQLTableConfig(TableConfig):
         }
 
     def _load_new_index_value(self):
-        query = 'SELECT MAX("{}") AS index_value FROM "{}";'.format(
+        query = 'SELECT MAX({}) AS index_value FROM "{}";'.format(
             self.index_column, self.source_table_name
         )
         return self.query_fetchone(query)["index_value"]


### PR DESCRIPTION
If someone wants a quoted reserved word as an index column they can pass a quoted string in the yaml, there are a few ways to do that.