### PR TITLE
Add container for building and serving the docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,9 @@ RUN python3.7 -m pip install virtualenv && \
 
 WORKDIR /app
 
-COPY setup.py setup.cfg README.md ./
+COPY setup.py setup.cfg README.rst ./
 COPY druzhba/ druzhba/
+COPY docs/ docs/
 
 ENV PATH=/home/venv/druzhba/bin:$PATH
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     stop_grace_period: 30s"
     environment:
       MYSQL_ROOT_PASSWORD: 'mysql_root_password'
+
   test:
     build:
       context: .
@@ -33,6 +34,14 @@ services:
       - .:/app
     networks:
       - druzhba
+
+  docs:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "7777:8000"
+    command: bash -c "pip install -e .[dev] && cd ./docs && make html && cd ./_build/html && python -m http.server 8000"
 
 networks:
   druzhba:


### PR DESCRIPTION
I was trying to review [this docs PR](https://github.com/seatgeek/druzhba/pull/33), so I added a docker-compose container that will build and serve the docs locally at http://localhost:7777/. Also, it looks like the `Dockerfile` is currently broken because the `README.md` was replaced with `README.rst`.