### PR TITLE
Don't require a specific string template pattern for schema errors

### DIFF
--- a/druzhba/main.py
+++ b/druzhba/main.py
@@ -158,9 +158,10 @@ def _process_database(
 
                 advance_to_next_table = True
 
-            except (InvalidSchemaError, MigrationError) as e:
-                logger.error(
-                    str(e), table.destination_schema_name, table.destination_table_name,
+            except (InvalidSchemaError, MigrationError):
+                logger.exception(
+                    "Error preparing target table %s.%s",
+                    table.destination_schema_name, table.destination_table_name
                 )
                 advance_to_next_table = True
 


### PR DESCRIPTION
The `InvalidSchemaError` raised when PKs are found missing was lacking the template parameters expected by the logging in `main`. This removes the expectation that these exceptions take two template parameters, which I think is a weird and brittle pattern.