### PR TITLE
Revert run_template_data to index query. Add integration test

### DIFF
--- a/druzhba/table.py
+++ b/druzhba/table.py
@@ -602,7 +602,8 @@ class TableConfig(object):
                 query = template.render(
                     db=self.db_template_data,
                     table=self.table_template_data,
-                    run=self.run_template_data,
+                    # Cannot include the run template data
+                    # here because we do not know the index values yet
                 )
                 self._new_index_value = self.query_fetchone(query)["index_value"]
 

--- a/test/integration/config/mysqltest.yaml
+++ b/test/integration/config/mysqltest.yaml
@@ -19,11 +19,10 @@ tables:
       - updated_at
     index_column: updated_at
     not_null_date: true
-#  - source_table_name: test_null_datetime
-#    destination_table_name: test_null_datetime
-#    destination_schema_name: druzhba_test
-#    distribution_key: pk
-#    sort_keys:
-#     - updated_at
-#    index_column: updated_at
-#    not_null_date: false
+  - source_table_name: test_index_sql_append_only
+    destination_table_name: test_index_sql_append_only
+    destination_schema_name: druzhba_test
+    append_only: true
+    index_sql: >-
+      SELECT GREATEST(created_at, deleted_at) AS index_value
+      FROM test_index_sql_append_only


### PR DESCRIPTION
Fixes a bug where providing `index_sql` in a yaml template would cause an infinite loop, since `run_template_data` references `new_index_value`.