### PR TITLE
Add options for connecting to Postgres

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -53,7 +53,7 @@ These aliases point to other files in the same directory, e.g. ``pgtest.yaml``.
 For an entry in ``sources``:
 
 - ``alias``: an arbitrary name used to reference a single source databsae
-- ``type``: indicates which database driver Druzhba should use. ``postgres``, 
+- ``type``: indicates which database driver Druzhba should use. ``postgres``,
   ``mysql``, or ``mssql``.
 - ``enabled``: if false, indicates that while this database is configured, a
   Druzhba run should not include it by default. It may still be requested
@@ -94,6 +94,8 @@ Database Configuration
 ----------------------
 
 ``<db_alias>.yaml`` defines the configuration for a specific source database.
+Like the pipeline configuration, this also supports interpolation from
+environment variables using ``${ENV_VAR}``.
 
 Other top-level keys in this file are:
 
@@ -106,7 +108,10 @@ Other top-level keys in this file are:
     used in the database connection.
 
 - ``connection_string``: an explicit connection URI like
-  ``protocol://user:pass@host:post/database_name`` in most cases.
+  ``protocol://user:pass@host:post/database_name`` in most cases. Note that user
+  and password must be URL encoded if there are special characters like ``?``.
+  Additional parameter keywords can also be passed via the connection string,
+  like ``protocol://user:pass@host:post/database_name?keyword=value&key=val``
 - ``connection_string_env``: an alternate environment variable for this
   database's `connection_string`.
 
@@ -125,7 +130,7 @@ Options configuring the creation of the target table for automatic tables.
 
 - ``destination_name``: desired table name in target database
 - ``destination_schema``: schema in target database. *This schema must already
-  exist*. 
+  exist*.
 - ``distribution_key``: Optional. A single column to be used as the table
   ``distkey``. It should be unique or mostly unique. Good examples are primary
   key IDs and high-resolution timestamps. You can read more about distkeys_

--- a/druzhba/db.py
+++ b/druzhba/db.py
@@ -11,7 +11,9 @@ from druzhba.mysql import MySQLTableConfig
 from druzhba.postgres import PostgreSQLTableConfig
 
 ConnectionParams = namedtuple(
-    "ConnectionParams", ["name", "host", "port", "user", "password", "additional"]
+    "ConnectionParams",
+    ["name", "host", "port", "user", "password", "additional"],
+    defaults=(None)  # default "additional" to None
 )
 
 

--- a/druzhba/db.py
+++ b/druzhba/db.py
@@ -1,6 +1,6 @@
 import os
 from collections import namedtuple
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 import psycopg2
 import pymssql
@@ -11,7 +11,7 @@ from druzhba.mysql import MySQLTableConfig
 from druzhba.postgres import PostgreSQLTableConfig
 
 ConnectionParams = namedtuple(
-    "ConnectionParams", ["name", "host", "port", "user", "password"]
+    "ConnectionParams", ["name", "host", "port", "user", "password", "additional"]
 )
 
 
@@ -114,4 +114,5 @@ class DatabaseConfig(object):
             port=parsed.port,
             user=parsed.username,
             password=parsed.password,
+            additional=parse_qs(parsed.query),
         )

--- a/druzhba/db.py
+++ b/druzhba/db.py
@@ -13,7 +13,7 @@ from druzhba.postgres import PostgreSQLTableConfig
 ConnectionParams = namedtuple(
     "ConnectionParams",
     ["name", "host", "port", "user", "password", "additional"],
-    defaults=(None, )  # default "additional" to None
+    defaults=(None,),  # default "additional" to None
 )
 
 

--- a/druzhba/db.py
+++ b/druzhba/db.py
@@ -1,6 +1,6 @@
 import os
 from collections import namedtuple
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, unquote, urlparse
 
 import psycopg2
 import pymssql
@@ -112,7 +112,7 @@ class DatabaseConfig(object):
             name=self._object_schema_name or parsed.path.lstrip("/"),
             host=parsed.hostname,
             port=parsed.port,
-            user=parsed.username,
-            password=parsed.password,
+            user=unquote(parsed.username),
+            password=unquote(parsed.password),
             additional={k: v[0] for k, v in parse_qs(parsed.query).items()},
         )

--- a/druzhba/db.py
+++ b/druzhba/db.py
@@ -114,5 +114,5 @@ class DatabaseConfig(object):
             port=parsed.port,
             user=parsed.username,
             password=parsed.password,
-            additional=parse_qs(parsed.query),
+            additional={k: v[0] for k, v in parse_qs(parsed.query).items()},
         )

--- a/druzhba/db.py
+++ b/druzhba/db.py
@@ -13,7 +13,7 @@ from druzhba.postgres import PostgreSQLTableConfig
 ConnectionParams = namedtuple(
     "ConnectionParams",
     ["name", "host", "port", "user", "password", "additional"],
-    defaults=(None)  # default "additional" to None
+    defaults=(None, )  # default "additional" to None
 )
 
 

--- a/druzhba/main.py
+++ b/druzhba/main.py
@@ -69,6 +69,7 @@ def _process_database(
     rebuild=None,
 ):
     dbconfig, missing_vars = load_config_file("{}/{}.yaml".format(CONFIG_DIR, db_alias))
+    _handle_missing_vars(missing_vars)
     db = DatabaseConfig(
         db_alias,
         db_type,
@@ -233,6 +234,16 @@ def _process_database(
         )
 
 
+def _handle_missing_vars(missing_vars):
+    if not COMPILE_ONLY and not PRINT_SQL_ONLY and not VALIDATE_ONLY:
+        if missing_vars:
+            logger.error(
+                "Could not find required environment variable(s): %s",
+                ", ".join(missing_vars),
+            )
+            sys.exit(1)
+
+
 @monitor.timer("full-run-time")
 def run(args):
     # pylint: disable=global-statement
@@ -260,13 +271,7 @@ def run(args):
     VALIDATE_ONLY = args.validate_only
 
     destination_config, missing_vars = load_destination_config(CONFIG_DIR)
-    if not COMPILE_ONLY and not PRINT_SQL_ONLY and not VALIDATE_ONLY:
-        if missing_vars:
-            logger.error(
-                "Could not find required environment variable(s): %s",
-                ", ".join(missing_vars),
-            )
-            sys.exit(1)
+    _handle_missing_vars(missing_vars)
 
     index_schema = destination_config["index"]["schema"]
     index_table = destination_config["index"]["table"]

--- a/druzhba/postgres.py
+++ b/druzhba/postgres.py
@@ -292,7 +292,7 @@ class PostgreSQLTableConfig(TableConfig):
                 SELECT a.attname
                 FROM pg_index i
                     JOIN pg_attribute a ON a.attrelid = i.indrelid
-                                        AND a.attnum = ANY(i.indkey)
+                                        AND a.attnum = ANY(string_to_array(textin(int2vectorout(i.indkey)), ' '))
                 WHERE i.indrelid = '{}'::regclass
                     AND i.indisprimary;
                 """.format(
@@ -307,7 +307,7 @@ class PostgreSQLTableConfig(TableConfig):
                 """
             SELECT column_name
             FROM information_schema.columns
-            WHERE table_schema = CURRENT_SCHEMA
+            WHERE table_schema = CURRENT_SCHEMA()
                 AND "table_name"= '{}'
                 AND column_name NOT IN ('{}')
             ORDER BY ordinal_position

--- a/druzhba/postgres.py
+++ b/druzhba/postgres.py
@@ -64,13 +64,18 @@ class PostgreSQLTableConfig(TableConfig):
 
     @property
     def connection_vars(self):
-        return {
+        parameters = {
             "database": self.db_name,
             "host": self.db_host,
             "port": self.db_port,
             "user": self.db_user,
             "password": self.db_password,
         }
+
+        if self.db_additional_parameters:
+            parameters.update(self.db_additional_parameters)
+
+        return parameters
 
     @property
     def pg_types(self):

--- a/druzhba/postgres.py
+++ b/druzhba/postgres.py
@@ -291,9 +291,10 @@ class PostgreSQLTableConfig(TableConfig):
                     """
                 SELECT a.attname
                 FROM pg_index i
-                    JOIN pg_attribute a ON a.attrelid = i.indrelid
-                                        AND a.attnum = ANY(string_to_array(textin(int2vectorout(i.indkey)), ' '))
-                WHERE i.indrelid = '{}'::regclass
+                    JOIN pg_attribute a
+                        ON a.attrelid = i.indrelid
+                        AND a.attnum::TEXT = ANY(STRING_TO_ARRAY(TEXTIN(INT2VECTOROUT(i.indkey)), ' '))
+                WHERE i.indrelid = '{}'::REGCLASS
                     AND i.indisprimary;
                 """.format(
                         self.source_table_name

--- a/druzhba/table.py
+++ b/druzhba/table.py
@@ -251,6 +251,7 @@ class TableConfig(object):
         self.db_name = db_connection_params.name
         self.db_user = db_connection_params.user
         self.db_password = db_connection_params.password
+        self.db_additional_parameters = db_connection_params.additional
         self._columns = None
         self.columns_to_drop = columns_to_drop or []
         self.destination_table_name = destination_table_name
@@ -905,7 +906,7 @@ class TableConfig(object):
 
         query = """
             INSERT INTO "public"."table_load_detail" VALUES (
-                %(task_id)s, %(class_name)s, %(task_date_params)s, 
+                %(task_id)s, %(class_name)s, %(task_date_params)s,
                 %(task_other_params)s, %(target_table)s, %(start_dt)s,
                 %(end_dt)s, %(run_time_sec)s, %(extract_task_update_id)s,
                 %(data_path)s, %(manifest_cleaned)s, %(rows_inserted)s,
@@ -1111,7 +1112,9 @@ class TableConfig(object):
             ]
             constraint_string = " AND ".join(constraints)
             return 'DELETE FROM "{}" USING "{}" WHERE {};'.format(
-                self.destination_table_name, self.staging_table_name, constraint_string,
+                self.destination_table_name,
+                self.staging_table_name,
+                constraint_string,
             )
         else:
             # Should only land here when append_only
@@ -1119,8 +1122,8 @@ class TableConfig(object):
             return None
 
     def get_grant_sql(self, cursor):
-        """ Get SQL statements to restore permissions
-        to the staging table after a rebuild. """
+        """Get SQL statements to restore permissions
+        to the staging table after a rebuild."""
 
         get_permissions_sql = """
         SELECT

--- a/druzhba/table.py
+++ b/druzhba/table.py
@@ -1283,17 +1283,22 @@ class TableConfig(object):
                 self.logger.info("Swapping staging table into %s", destination_table)
                 # DNE overrides rebuild, so we can assume the table exists
                 query = generate_drop_query(destination_table)
+                self.logger.debug(query)
                 cur.execute(query)
                 query = generate_rename_query(staging_table, destination_table)
+                self.logger.debug(query)
                 cur.execute(query)
                 query = generate_count_query(destination_table)
+                self.logger.debug(query)
                 cur.execute(query)
                 self.rows_inserted = cur.fetchall()[0]
             else:
                 query = generate_insert_all_query(staging_table, destination_table)
+                self.logger.debug(query)
                 cur.execute(query)
                 self.rows_inserted = cur.rowcount
                 query = generate_drop_query(staging_table)
+                self.logger.debug(query)
                 cur.execute(query)
             cur.execute("END TRANSACTION;")
             self.register_and_cleanup()

--- a/test/integration/test_postgres_to_redshift.py
+++ b/test/integration/test_postgres_to_redshift.py
@@ -383,3 +383,12 @@ class TestDataTypes(BaseTestPostgresToRedshift):
             result = cur.fetchall()
             self.assertTupleEqual(result[0], (1, t.t0, "citext1"))
             self.assertTupleEqual(result[1], (2, t.t1, "Citext2"))
+
+    def tearDown(self):
+        with self.target_conn.cursor() as cur:
+            cur.execute(
+                """
+            DROP TABLE IF EXISTS druzhba_test.test_basic;
+            DROP TABLE IF EXISTS druzhba_test.pipeline_table_index;
+            """
+            )

--- a/test/unit/test_db.py
+++ b/test/unit/test_db.py
@@ -1,0 +1,67 @@
+import unittest
+
+from druzhba.db import ConnectionParams, DatabaseConfig
+
+
+class DbTest(unittest.TestCase):
+    def test_connection_string(self):
+        config = DatabaseConfig(
+            'test_db',
+            'mysql',
+            ('postgresql://test_user:test_password@test-db.prod:5439/'
+                'test_db_name')
+        )
+
+        self.assertIsNotNone(config)
+
+    def test_encoded_connection_string(self):
+        config = DatabaseConfig(
+            'test_db',
+            'mysql',
+            ('postgresql://test_user:test_%3Fpassword@test-db.prod:5439/'
+                'test_db_name')
+        )
+
+        params = config.get_connection_params()
+        self.assertIsNotNone(params)
+        self.assertEqual(params.password, 'test_?password')
+        self.assertEqual(params.additional, {})
+
+    def test_unencoded_connection_string(self):
+        """
+        '?' in the password will cause the urlparse to fail
+        """
+        config = DatabaseConfig(
+            'test_db',
+            'mysql',
+            ('postgresql://test_user:test_?password@test-db.prod:5439/'
+                'test_db_name')
+        )
+
+        self.assertRaises(
+            ValueError,
+            config.get_connection_params
+        )
+
+    def test_additional_parameters(self):
+        config = DatabaseConfig(
+            'test_db',
+            'mysql',
+            ('postgresql://test_user:test_password@test-db.prod:5439/'
+                'test_db_name?sslmode=disable&connect_timeout=60')
+        )
+
+        params = config.get_connection_params()
+        self.assertIsNotNone(params)
+        self.assertEqual(
+            params.additional,
+            {'sslmode': 'disable', 'connect_timeout': '60'}
+        )
+
+
+class ConnectionParamsTest(unittest.TestCase):
+    def test_bad_connection_params(self):
+        self.assertRaises(
+            TypeError,
+            ConnectionParams,
+            "name", "host", "port", "user")

--- a/test/unit/test_db.py
+++ b/test/unit/test_db.py
@@ -6,25 +6,26 @@ from druzhba.db import ConnectionParams, DatabaseConfig
 class DbTest(unittest.TestCase):
     def test_connection_string(self):
         config = DatabaseConfig(
-            'test_db',
-            'mysql',
-            ('postgresql://test_user:test_password@test-db.prod:5439/'
-                'test_db_name')
+            "test_db",
+            "mysql",
+            ("postgresql://test_user:test_password@test-db.prod:5439/" "test_db_name"),
         )
 
         self.assertIsNotNone(config)
 
     def test_encoded_connection_string(self):
         config = DatabaseConfig(
-            'test_db',
-            'mysql',
-            ('postgresql://test_user:test_%3Fpassword@test-db.prod:5439/'
-                'test_db_name')
+            "test_db",
+            "mysql",
+            (
+                "postgresql://test_user:test_%3Fpassword@test-db.prod:5439/"
+                "test_db_name"
+            ),
         )
 
         params = config.get_connection_params()
         self.assertIsNotNone(params)
-        self.assertEqual(params.password, 'test_?password')
+        self.assertEqual(params.password, "test_?password")
         self.assertEqual(params.additional, {})
 
     def test_unencoded_connection_string(self):
@@ -32,36 +33,30 @@ class DbTest(unittest.TestCase):
         '?' in the password will cause the urlparse to fail
         """
         config = DatabaseConfig(
-            'test_db',
-            'mysql',
-            ('postgresql://test_user:test_?password@test-db.prod:5439/'
-                'test_db_name')
+            "test_db",
+            "mysql",
+            ("postgresql://test_user:test_?password@test-db.prod:5439/" "test_db_name"),
         )
 
-        self.assertRaises(
-            ValueError,
-            config.get_connection_params
-        )
+        self.assertRaises(ValueError, config.get_connection_params)
 
     def test_additional_parameters(self):
         config = DatabaseConfig(
-            'test_db',
-            'mysql',
-            ('postgresql://test_user:test_password@test-db.prod:5439/'
-                'test_db_name?sslmode=disable&connect_timeout=60')
+            "test_db",
+            "mysql",
+            (
+                "postgresql://test_user:test_password@test-db.prod:5439/"
+                "test_db_name?sslmode=disable&connect_timeout=60"
+            ),
         )
 
         params = config.get_connection_params()
         self.assertIsNotNone(params)
         self.assertEqual(
-            params.additional,
-            {'sslmode': 'disable', 'connect_timeout': '60'}
+            params.additional, {"sslmode": "disable", "connect_timeout": "60"}
         )
 
 
 class ConnectionParamsTest(unittest.TestCase):
     def test_bad_connection_params(self):
-        self.assertRaises(
-            TypeError,
-            ConnectionParams,
-            "name", "host", "port", "user")
+        self.assertRaises(TypeError, ConnectionParams, "name", "host", "port", "user")

--- a/test/unit/test_postgres.py
+++ b/test/unit/test_postgres.py
@@ -25,8 +25,12 @@ class PostgresTest(unittest.TestCase):
         more_params_table_config = PostgreSQLTableConfig(
             "db",
             ConnectionParams(
-                "name", "host", "port", "user", "password",
-                {'connect_timeout': "60", 'sslmode': "disable"}
+                "name",
+                "host",
+                "port",
+                "user",
+                "password",
+                {"connect_timeout": "60", "sslmode": "disable"},
             ),
             "table",
             "schema",
@@ -39,12 +43,12 @@ class PostgresTest(unittest.TestCase):
         self.assertEqual(
             more_params_table_config.connection_vars,
             {
-                'database': "name",
-                'host': "host",
-                'port': "port",
-                'user': "user",
-                'password': "password",
-                'connect_timeout': "60",
-                'sslmode': "disable"
-            }
+                "database": "name",
+                "host": "host",
+                "port": "port",
+                "user": "user",
+                "password": "password",
+                "connect_timeout": "60",
+                "sslmode": "disable",
+            },
         )

--- a/test/unit/test_postgres.py
+++ b/test/unit/test_postgres.py
@@ -20,3 +20,31 @@ class PostgresTest(unittest.TestCase):
     def test_init(self):
         table = self.table_config()
         self.assertIsNotNone(table)
+
+    def test_additional_parameters(self):
+        more_params_table_config = PostgreSQLTableConfig(
+            "db",
+            ConnectionParams(
+                "name", "host", "port", "user", "password",
+                {'connect_timeout': "60", 'sslmode': "disable"}
+            ),
+            "table",
+            "schema",
+            "source",
+            "index_schema",
+            "index_table",
+            index_column="id",
+        )
+        self.assertIsNotNone(more_params_table_config)
+        self.assertEqual(
+            more_params_table_config.connection_vars,
+            {
+                'database': "name",
+                'host': "host",
+                'port': "port",
+                'user': "user",
+                'password': "password",
+                'connect_timeout': "60",
+                'sslmode': "disable"
+            }
+        )


### PR DESCRIPTION
* Allows for additional parameters to the `connection_string` (e.g. `sslmode`). These are collected from the query string in the connection url
* Fixes an issue when the username or password in the connection string has characters that need to be url-encoded (for example, if a password has `?` in it)
* Enable environment variable parsing on the database YAML
* Update the Postgres queries for table indices and columns to be compatible with Redshift
* Added tests
* Updated docs

I think there are some files that `black` will reformat, but I left alone the ones I didn't touch.

Unit test and integration tests run.

I tested using a Redshift source (via the Postgres source type) and was able to confirm a successful run.