### PR TITLE
Set old_index_value to None for full refresh

### DIFF
--- a/druzhba/table.py
+++ b/druzhba/table.py
@@ -582,6 +582,8 @@ class TableConfig(object):
 
     @property
     def old_index_value(self):
+        if self.full_refresh:
+            return None
         # we use 'notset' rather than None because None is a valid output
         if self._old_index_value is "notset":
             self._old_index_value = self._load_old_index_value()

--- a/test/unit/test_table.py
+++ b/test/unit/test_table.py
@@ -208,6 +208,25 @@ class TableTest(unittest.TestCase):
                     table_config.where_clause(), "\nWHERE id > '13' AND id <= '42'"
                 )
 
+    def test_full_refresh(self):
+        with patch(
+            "druzhba.table.TableConfig._load_old_index_value", new_callable=Mock
+        ) as loiv:
+            loiv.return_value = 13
+            # no index column
+            table_config = TableConfig(
+                "alias",
+                mock_conn,
+                "table",
+                "schema",
+                "source",
+                "index_schema",
+                "index_table",
+                index_column="id",
+                full_refresh=True,
+            )
+            self.assertEqual(table_config.old_index_value, None)
+
 
 class TestTableIndexLogic(unittest.TestCase):
     logging.disable(logging.CRITICAL)


### PR DESCRIPTION
Previously, if `query_file` was set for a table, a full refresh would not work because the `run.old_index_value` would still have a value and the custom SQL would respect that.

Now, `old_index_value` always returns `None` if full refreshing, which enables full refreshes if there is a `query_file`.

There are some files that black will reformat, but I left alone the ones I didn't touch.

Unit test and integration tests run.