### PR TITLE
Allow database config variables to be defined in pipeline config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,5 +96,5 @@ rst_prolog = """
 .. |example-link| raw:: html
 
     <a href="https://github.com/seatgeek/druzhba/tree/{version}/test/integration/config">examples</a>
-""".format(version=version)
+""".format(version=release)
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -31,9 +31,10 @@ Pipeline Configuration
 An example can be found in the |example-link|.
 
 The top level ``_pipeline.yaml`` defines details about the pipeline as a whole
-as well as connection info for the target database. We use a modified parser for
-YAML extended with support for interpolation like ``${REDSHIFT_URL}`` which will
-inject the value of the ``REDSHIFT_URL`` environment variable.
+as well as connection info for the target database (and optionally the source
+databases). We use a modified parser for YAML extended with support for
+interpolation like ``${REDSHIFT_URL}`` which will inject the value of the
+``REDSHIFT_URL`` environment variable.
 
 Besides the target configuration fields, ``_pipeline.yaml`` also includes a list
 of source databases under the ``sources`` element.
@@ -55,9 +56,15 @@ For an entry in ``sources``:
 - ``alias``: an arbitrary name used to reference a single source databsae
 - ``type``: indicates which database driver Druzhba should use. ``postgres``,
   ``mysql``, or ``mssql``.
-- ``enabled``: if false, indicates that while this database is configured, a
-  Druzhba run should not include it by default. It may still be requested
-  explicitly by passing its alias to ``--database``.
+- ``enabled``: (optional, default is true) if false, indicates that while this
+  database is configured, a Druzhba run should not include it by default. It may
+  still be requested explicitly by passing its alias to ``--database``.
+- ``config_name``: (optional) indicates the name of the source database config
+  YAML if not ``{alias}.yaml``.
+- ``config``: (optional) a dictionary that overrides the keys specifed in the
+  source database config YAML. Valid keys here are ``connection_string``,
+  ``connection_string_env``, and ``data``. See `database configuration
+  <#database-configuration>`_ for more info.
 
 Supported fields for the connection to the target database (currently only
 Redshift):

--- a/druzhba/main.py
+++ b/druzhba/main.py
@@ -267,7 +267,7 @@ def set_up_database(
         connection_string_env=db_config_override.get(
             "connection_string_env", dbconfig.get("connection_string_env")
         ),
-        object_schema_name=dbconfig.get("data", {}).get("object_schema_name"),
+        object_schema_name=db_template_data.get("object_schema_name"),
         db_template_data=db_template_data,
     )
 

--- a/test/init_psql/initdb_citext.sh
+++ b/test/init_psql/initdb_citext.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 # Adds the citext extension to database and test database
-"${psql[@]}" <<- 'EOSQL'
-\c druzhba_test
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname druzhba_test <<-EOSQL
 CREATE EXTENSION IF NOT EXISTS citext;
 EOSQL

--- a/test/integration/config/_pipeline.yaml
+++ b/test/integration/config/_pipeline.yaml
@@ -13,3 +13,10 @@ sources:
     type: postgres
   - alias: mysqltest
     type: mysql
+  - alias: pgtest_alias
+    type: postgres
+    enabled: false
+    config_name: pgtest_data  # explicitly specify database config file
+    config:
+      data:
+        bar: bar

--- a/test/integration/config/pgtest_data.yaml
+++ b/test/integration/config/pgtest_data.yaml
@@ -1,5 +1,7 @@
+# sample database config file, not used in the integration testing
+# has sample data that can be overriden during testing
 ---
-connection_string: test_connection_string
+connection_string: postgresql://user:password@host:1234/test_db
 data:
   bar: foo
 tables:

--- a/test/integration/config/pgtest_data.yaml
+++ b/test/integration/config/pgtest_data.yaml
@@ -1,0 +1,18 @@
+---
+connection_string: test_connection_string
+data:
+  bar: foo
+tables:
+  - source_table_name: test_basic
+    destination_table_name: test_basic
+    destination_schema_name: druzhba_test
+    distribution_key: pk
+    sort_keys:
+      - updated_at
+    index_column: updated_at
+    primary_key:
+      - pk
+    columns_to_drop:
+      - drop1
+    type_map:
+      enum1: varchar(15)

--- a/test/unit/test_main.py
+++ b/test/unit/test_main.py
@@ -30,7 +30,7 @@ class ProcessDbTest(unittest.TestCase):
 
         self.assertEqual(db.database_alias, "pgtest")
         self.assertEqual(db.database_type, "postgres")
-        self.assertEqual(db._connection_string, "test_connection_string")
+        self.assertEqual(db._connection_string, "postgresql://user:password@host:1234/test_db")
         self.assertEqual(len(dbconfig["tables"]), 1)
 
     def test_conn_string(self):

--- a/test/unit/test_main.py
+++ b/test/unit/test_main.py
@@ -1,0 +1,102 @@
+import unittest
+from unittest.mock import patch
+
+from druzhba.main import set_up_database
+
+
+class ProcessDbTest(unittest.TestCase):
+    def test_basic_config(self):
+        db, dbconfig = set_up_database(
+            "pgtest",
+            "postgres",
+            None,
+            None,
+            "test/integration/config",
+        )
+
+        self.assertEqual(db.database_alias, "pgtest")
+        self.assertEqual(db.database_type, "postgres")
+        self.assertEqual(db._connection_string, None)
+        self.assertEqual(len(dbconfig["tables"]), 1)
+
+    def test_config_name(self):
+        db, dbconfig = set_up_database(
+            "pgtest",
+            "postgres",
+            "pgtest_data",
+            None,
+            "test/integration/config",
+        )
+
+        self.assertEqual(db.database_alias, "pgtest")
+        self.assertEqual(db.database_type, "postgres")
+        self.assertEqual(db._connection_string, "test_connection_string")
+        self.assertEqual(len(dbconfig["tables"]), 1)
+
+    def test_conn_string(self):
+        db, _ = set_up_database(
+            "pgtest",
+            "postgres",
+            None,
+            {"connection_string": "fake_connection_string"},
+            "test/integration/config",
+        )
+
+        self.assertEqual(db._connection_string, "fake_connection_string")
+
+    def test_conn_string_override(self):
+        db, _ = set_up_database(
+            "pgtest",
+            "postgres",
+            "pgtest_data",
+            {"connection_string": "fake_connection_string"},
+            "test/integration/config",
+        )
+
+        self.assertEqual(db._connection_string, "fake_connection_string")
+
+    def test_conn_string_env(self):
+        db, _ = set_up_database(
+            "pgtest",
+            "postgres",
+            None,
+            {"connection_string_env": "FAKE_CONNECTION_STRING_ENV"},
+            "test/integration/config",
+        )
+
+        self.assertEqual(db._connection_string_env, "FAKE_CONNECTION_STRING_ENV")
+
+    def test_data(self):
+        db, _ = set_up_database(
+            "pgtest",
+            "postgres",
+            None,
+            {"data": {"foo": "bar", "foobar": "hello"}},
+            "test/integration/config",
+        )
+
+        self.assertEqual(db._db_template_data, {"foo": "bar", "foobar": "hello"})
+
+    def test_data_add(self):
+        db, _ = set_up_database(
+            "pgtest",
+            "postgres",
+            "pgtest_data",
+            {"data": {"foo": "bar", "foobar": "hello"}},
+            "test/integration/config",
+        )
+
+        self.assertEqual(
+            db._db_template_data, {"foo": "bar", "foobar": "hello", "bar": "foo"}
+        )
+
+    def test_data_override(self):
+        db, _ = set_up_database(
+            "pgtest",
+            "postgres",
+            "pgtest_data",
+            {"data": {"foo": "bar", "bar": "nope"}},
+            "test/integration/config",
+        )
+
+        self.assertEqual(db._db_template_data, {"foo": "bar", "bar": "nope"})


### PR DESCRIPTION
For increased flexibility, we would like to be able to define a source database config YAML separately from the database alias in `_pipeline.yaml`. This is particularly useful when we have the same source database config we want to apply against multiple databases.

Now:
* `config_name` in `_pipeline.yaml` allows a different location of the source database config YAML besides `alias`
* `config` in `_pipeline.yaml` allows `connection_string`, `connection_string_env`, and `data` to override what is in the source database config YAML

Unit test and integration tests run.