### PR TITLE
Log the new index value when it is first loaded

### DIFF
--- a/druzhba/table.py
+++ b/druzhba/table.py
@@ -609,6 +609,7 @@ class TableConfig(object):
                 self._new_index_value = self._load_new_index_value()
             else:
                 self._new_index_value = None
+            self.logger.info("New index found: %s", self._new_index_value)
         if self.query_file and self.index_sql and self._new_index_value is None:
             # Handles a special case where the index_sql query returns no rows
             # but the custom sql file is expecting both old and new index values


### PR DESCRIPTION
This change is particularly related to some instances we've seen
where there's a huge time delta (on the scale of hours) between
loading the old index value and starting the extract query (or at
least between the timestamps of the relevant "Index found" and
"Extracting" logs) but we can't exactly place where the query to
load the new index value falls on that timeline.