### PR TITLE
Revert "Cache the result of get_sql_description on TableConfig"

### DIFF
--- a/druzhba/mssql.py
+++ b/druzhba/mssql.py
@@ -49,7 +49,7 @@ class MSSQLTableConfig(TableConfig):
             "charset": "UTF-8",  # default, but be explicit
         }
 
-    def _get_sql_description(self, sql):
+    def get_sql_description(self, sql):
         table_attributes = {}  # TODO: retrieve table attributes
         with closing(pymssql.connect(**self.connection_vars)) as conn:
             with closing(conn.cursor(as_dict=True)) as cursor:

--- a/druzhba/mysql.py
+++ b/druzhba/mysql.py
@@ -142,7 +142,7 @@ class MySQLTableConfig(TableConfig):
             "charset": "utf8",
         }
 
-    def _get_sql_description(self, sql):
+    def get_sql_description(self, sql):
         table_attributes = {}  # TODO: retrieve table attributes
         with closing(pymysql.connect(**self.connection_vars)) as conn:
             with closing(conn.cursor(pymysql.cursors.SSDictCursor)) as cursor:

--- a/druzhba/postgres.py
+++ b/druzhba/postgres.py
@@ -138,7 +138,7 @@ class PostgreSQLTableConfig(TableConfig):
         )
         return self.query_fetchone(query)["index_value"]
 
-    def _get_sql_description(self, sql):
+    def get_sql_description(self, sql):
         if self.query_file is None:
             table_attributes = self._get_table_attributes()
             column_attributes = self._get_column_attributes()

--- a/druzhba/table.py
+++ b/druzhba/table.py
@@ -296,8 +296,6 @@ class TableConfig(object):
         self.logger = logging.getLogger(f"druzhba.{database_alias}.{source_table_name}")
         self.s3 = Session().client("s3")
 
-        self._sql_description_mapping = {}
-
     @classmethod
     def _clean_type_map(cls, type_map):
         if not type_map:
@@ -441,16 +439,6 @@ class TableConfig(object):
         )
 
     def get_sql_description(self, sql):
-        # Both check_destination_table_status and extract load the description which involves actually
-        # executing a query against the source database. The cache here prevents us from doing so multiple times.
-        # In the typical case we'll only call this with a single distinct query, but the keyed cache plays
-        # it safe since the current API does allow for the result of get_query_sql() to change.
-        if sql not in self._sql_description_mapping:
-            self.logger.info("Getting SQL description for %s table %s", self.db_name, self.source_table_name)
-            self._sql_description_mapping[sql] = self._get_sql_description(sql)
-        return self._sql_description_mapping[sql]
-
-    def _get_sql_description(self, sql):
         raise NotImplementedError
 
     def get_query_sql(self):

--- a/test/unit/test_table.py
+++ b/test/unit/test_table.py
@@ -457,7 +457,7 @@ class TestUnloadCopy(unittest.TestCase):
         def get_destination_table_columns(self):
             return self._dw_columns
 
-        def _get_sql_description(self, sql):
+        def get_sql_description(self, sql):
             return {}, self._desc
 
         @property


### PR DESCRIPTION
Reverts seatgeek/druzhba#62

Deploying this commit we encountered an issue with the index table being updated without the actual data loaded in Redshift. Reverting the commit out allowed things to proceed as intended. The details still need to be investigated; I will follow up here with the details once identified.