### PR TITLE
Support numeric type with precision

### DIFF
--- a/druzhba/postgres.py
+++ b/druzhba/postgres.py
@@ -67,7 +67,7 @@ class PostgreSQLTableConfig(TableConfig):
 
         type_map_defaults.update(self.type_map)
         self.type_map = type_map_defaults
-        logger.info("type map for postgres table: "+ self.type_map)
+        logger.info(self.type_map)
 
     @property
     def connection_vars(self):

--- a/druzhba/postgres.py
+++ b/druzhba/postgres.py
@@ -220,12 +220,12 @@ class PostgreSQLTableConfig(TableConfig):
             ) in columns:
                 size_str = self._get_column_size(type_code, internal_size, precision, scale)
 
-                red_type = self._format_red_type(self.type_map.get(type_code, type_code), size_str, name)
+                redshift_type = self._format_redshift_type(self.type_map.get(type_code, type_code), size_str, name)
 
                 field_strs.append(
                     '"{name}" {type}{null_ok}'.format(
                         name=name,
-                        type=red_type,
+                        type=redshift_type,
                         null_ok="" if null_ok else " NOT NULL",
                     )
                 )
@@ -291,11 +291,11 @@ class PostgreSQLTableConfig(TableConfig):
 
         return size_str
 
-    def _format_red_type(self, type_name, size_str, name):
+    def _format_redshift_type(self, type_name, size_str, name):
         if name in self.type_map:
             return self.type_map[name]
         else:
-            return "{}{}".format(
+            return "{type}{size}".format(
                     type_name, size_str
                 )
 

--- a/druzhba/postgres.py
+++ b/druzhba/postgres.py
@@ -224,7 +224,7 @@ class PostgreSQLTableConfig(TableConfig):
             ) in columns:
                 size_str = self._get_column_size(type_code, internal_size, precision, scale)
 
-                red_type = self._format_red_type(self.type_map.get(type_code, type_code), size_str)
+                red_type = self._format_red_type(self.type_map.get(type_code, type_code), size_str, name)
                 logger.info("type for column with name %s is %s with size %s from type map default %s", name, red_type, size_str, self.type_map.get(type_code, type_code))
 
                 field_strs.append(
@@ -296,14 +296,10 @@ class PostgreSQLTableConfig(TableConfig):
 
         return size_str
 
-    def _format_red_type(self, type_name, size_str):
-        try:
-            paren_index = type_name.index('(')
-            main_type = type_name[:paren_index]
-            return "{}{}".format(
-                    main_type, size_str
-                )
-        except ValueError: # no ( found in type_name, no need to truncate
+    def _format_red_type(self, type_name, size_str, name):
+        if name in self.type_map:
+            return self.type_map[name]
+        else:
             return "{}{}".format(
                     type_name, size_str
                 )

--- a/druzhba/postgres.py
+++ b/druzhba/postgres.py
@@ -3,15 +3,12 @@ from contextlib import closing
 import psycopg2
 import psycopg2.extensions
 import psycopg2.extras
-import logging
 
 from druzhba.config import CONFIG_DIR
 from druzhba.table import TableConfig, load_query
 
 psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)
 psycopg2.extensions.register_type(psycopg2.extensions.UNICODEARRAY)
-
-logger = logging.getLogger("druzhba.main")
 
 ENCODING = "UTF8"
 MAX_DECIMAL_PRECISION = 38
@@ -67,7 +64,6 @@ class PostgreSQLTableConfig(TableConfig):
 
         type_map_defaults.update(self.type_map)
         self.type_map = type_map_defaults
-        logger.info(self.type_map)
 
     @property
     def connection_vars(self):
@@ -225,7 +221,6 @@ class PostgreSQLTableConfig(TableConfig):
                 size_str = self._get_column_size(type_code, internal_size, precision, scale)
 
                 red_type = self._format_red_type(self.type_map.get(type_code, type_code), size_str, name)
-                logger.info("type for column with name %s is %s with size %s from type map default %s", name, red_type, size_str, self.type_map.get(type_code, type_code))
 
                 field_strs.append(
                     '"{name}" {type}{null_ok}'.format(

--- a/druzhba/postgres.py
+++ b/druzhba/postgres.py
@@ -3,12 +3,15 @@ from contextlib import closing
 import psycopg2
 import psycopg2.extensions
 import psycopg2.extras
+import logging
 
 from druzhba.config import CONFIG_DIR
 from druzhba.table import TableConfig, load_query
 
 psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)
 psycopg2.extensions.register_type(psycopg2.extensions.UNICODEARRAY)
+
+logger = logging.getLogger("druzhba.main")
 
 ENCODING = "UTF8"
 MAX_DECIMAL_PRECISION = 38
@@ -64,6 +67,7 @@ class PostgreSQLTableConfig(TableConfig):
 
         type_map_defaults.update(self.type_map)
         self.type_map = type_map_defaults
+        logger.info("type map for postgres table: "+ self.type_map)
 
     @property
     def connection_vars(self):
@@ -221,6 +225,7 @@ class PostgreSQLTableConfig(TableConfig):
                 size_str = self._get_column_size(type_code, internal_size, precision, scale)
 
                 red_type = self._format_red_type(self.type_map.get(type_code, type_code), size_str)
+                logger.info("type for column with name {} is {} with size {} from type map default {}".format(name, red_type, size_str, self.type_map.get(type_code, type_code)))
 
                 field_strs.append(
                     '"{name}" {type}{null_ok}'.format(

--- a/druzhba/postgres.py
+++ b/druzhba/postgres.py
@@ -220,9 +220,8 @@ class PostgreSQLTableConfig(TableConfig):
             ) in columns:
                 size_str = self._get_column_size(type_code, internal_size, precision, scale)
 
-                red_type = "{}{}".format(
-                    self.type_map.get(type_code, type_code), size_str
-                )
+                red_type = self._format_red_type(self.type_map.get(type_code, type_code), size_str)
+
                 field_strs.append(
                     '"{name}" {type}{null_ok}'.format(
                         name=name,
@@ -291,6 +290,18 @@ class PostgreSQLTableConfig(TableConfig):
             size_str = "({})".format(length)
 
         return size_str
+
+    def _format_red_type(self, type_name, size_str):
+        try:
+            paren_index = type_name.index('(')
+            main_type = type_name[:paren_index]
+            return "{}{}".format(
+                    main_type, size_str
+                )
+        except ValueError: # no ( found in type_name, no need to truncate
+            return "{}{}".format(
+                    type_name, size_str
+                )
 
     def _format_column_query(self, column_name, data_type):
         # PostgreSQL's MONEY type is a bit strange. It's an 8-byte fixed fractional precision value

--- a/druzhba/postgres.py
+++ b/druzhba/postgres.py
@@ -225,7 +225,7 @@ class PostgreSQLTableConfig(TableConfig):
                 size_str = self._get_column_size(type_code, internal_size, precision, scale)
 
                 red_type = self._format_red_type(self.type_map.get(type_code, type_code), size_str)
-                logger.info("type for column with name {} is {} with size {} from type map default {}".format(name, red_type, size_str, self.type_map.get(type_code, type_code)))
+                logger.info("type for column with name %s is %s with size %s from type map default %s", name, red_type, size_str, self.type_map.get(type_code, type_code))
 
                 field_strs.append(
                     '"{name}" {type}{null_ok}'.format(

--- a/druzhba/postgres.py
+++ b/druzhba/postgres.py
@@ -296,7 +296,8 @@ class PostgreSQLTableConfig(TableConfig):
             return self.type_map[name]
         else:
             return "{type}{size}".format(
-                    type_name, size_str
+                    type=type_name, 
+                    size=size_str
                 )
 
     def _format_column_query(self, column_name, data_type):


### PR DESCRIPTION
The original precision/scale gets also appended (e.g. numeric(18,2) with a type_map['numeric'] = 'numeric(19,2)' ends up as numeric(18,2)(19,2). This will fix the bug.