### PR TITLE
per-column type map support added

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -199,8 +199,17 @@ Column-specific configuration:
 .. code-block:: yaml
 
   type_map:
-    - your_column_name: smallint
-    - other_column_name: varchar(70)
+    - your_type_name: smallint
+    - other_type_name: varchar(70)
+
+  - ``columns``: Optional. Specified within type_map section, and allows for per-type column overrides. 
+
+  .. code-block:: yaml
+
+    type_map:
+      your_type_name: numeric(10,2) // standard type map declaration
+      columns:
+        your_column_name: numeric(12,2) // per column type map declaration
 
 Other configuration options:
 

--- a/druzhba/postgres.py
+++ b/druzhba/postgres.py
@@ -220,7 +220,7 @@ class PostgreSQLTableConfig(TableConfig):
             ) in columns:
                 size_str = self._get_column_size(type_code, internal_size, precision, scale)
 
-                redshift_type = self._format_redshift_type(self.type_map.get(type_code, type_code), size_str, name)
+                redshift_type = self._format_redshift_type(self.type_map.get(type_code, type_code), size_str)
 
                 field_strs.append(
                     '"{name}" {type}{null_ok}'.format(
@@ -291,7 +291,7 @@ class PostgreSQLTableConfig(TableConfig):
 
         return size_str
 
-    def _format_redshift_type(self, type_name, size_str, name):
+    def _format_redshift_type(self, type_name, size_str):
         final_type = "{type}{size}".format(
                 type=type_name, 
                 size=size_str

--- a/druzhba/postgres.py
+++ b/druzhba/postgres.py
@@ -220,7 +220,7 @@ class PostgreSQLTableConfig(TableConfig):
             ) in columns:
                 size_str = self._get_column_size(type_code, internal_size, precision, scale)
 
-                redshift_type = self._format_redshift_type(self.type_map.get(type_code, type_code), size_str)
+                redshift_type = self._format_redshift_type(self.type_map.get(type_code, type_code), size_str, name)
 
                 field_strs.append(
                     '"{name}" {type}{null_ok}'.format(
@@ -291,14 +291,17 @@ class PostgreSQLTableConfig(TableConfig):
 
         return size_str
 
-    def _format_redshift_type(self, type_name, size_str):
-        final_type = "{type}{size}".format(
-                type=type_name, 
-                size=size_str
-            )
-        if final_type in self.type_map:
-            final_type = self.type_map[final_type]
-        return final_type
+    def _format_redshift_type(self, type_name, size_str, column_name):
+        if column_name in self.type_map['columns']:
+            return self.type_map['columns'][column_name]
+        else:
+            final_type = "{type}{size}".format(
+                    type=type_name, 
+                    size=size_str
+                )
+            if final_type in self.type_map:
+                final_type = self.type_map[final_type]
+            return final_type
 
     def _format_column_query(self, column_name, data_type):
         # PostgreSQL's MONEY type is a bit strange. It's an 8-byte fixed fractional precision value

--- a/druzhba/postgres.py
+++ b/druzhba/postgres.py
@@ -293,7 +293,7 @@ class PostgreSQLTableConfig(TableConfig):
         return size_str
 
     def _format_redshift_type(self, type_name, size_str, column_name):
-        if  TYPE_MAP_COLUMN_SECTION in self.type_map and column_name in self.type_map[TYPE_MAP_COLUMN_SECTION]:
+        if TYPE_MAP_COLUMN_SECTION in self.type_map and column_name in self.type_map[TYPE_MAP_COLUMN_SECTION]:
             return self.type_map[TYPE_MAP_COLUMN_SECTION][column_name]
         else:
             final_type = "{type}{size}".format(

--- a/druzhba/postgres.py
+++ b/druzhba/postgres.py
@@ -293,16 +293,20 @@ class PostgreSQLTableConfig(TableConfig):
         return size_str
 
     def _format_redshift_type(self, type_name, size_str, column_name):
-        if TYPE_MAP_COLUMN_SECTION in self.type_map and column_name in self.type_map[TYPE_MAP_COLUMN_SECTION]:
+        
+        hasColumnSection = TYPE_MAP_COLUMN_SECTION in self.type_map
+        hasColumnOverride = column_name in self.type_map[TYPE_MAP_COLUMN_SECTION]
+        
+        if hasColumnSection and hasColumnOverride:
             return self.type_map[TYPE_MAP_COLUMN_SECTION][column_name]
-        else:
-            final_type = "{type}{size}".format(
-                    type=type_name, 
-                    size=size_str
-                )
-            if final_type in self.type_map:
-                final_type = self.type_map[final_type]
-            return final_type
+     
+        final_type = "{type}{size}".format(
+                type=type_name, 
+                size=size_str
+            )
+        if final_type in self.type_map:
+            final_type = self.type_map[final_type]
+        return final_type
 
     def _format_column_query(self, column_name, data_type):
         # PostgreSQL's MONEY type is a bit strange. It's an 8-byte fixed fractional precision value

--- a/druzhba/postgres.py
+++ b/druzhba/postgres.py
@@ -292,13 +292,13 @@ class PostgreSQLTableConfig(TableConfig):
         return size_str
 
     def _format_redshift_type(self, type_name, size_str, name):
-        if name in self.type_map:
-            return self.type_map[name]
-        else:
-            return "{type}{size}".format(
-                    type=type_name, 
-                    size=size_str
-                )
+        final_type = "{type}{size}".format(
+                type=type_name, 
+                size=size_str
+            )
+        if final_type in self.type_map:
+            final_type = self.type_map[final_type]
+        return final_type
 
     def _format_column_query(self, column_name, data_type):
         # PostgreSQL's MONEY type is a bit strange. It's an 8-byte fixed fractional precision value

--- a/druzhba/postgres.py
+++ b/druzhba/postgres.py
@@ -220,7 +220,7 @@ class PostgreSQLTableConfig(TableConfig):
             ) in columns:
                 size_str = self._get_column_size(type_code, internal_size, precision, scale)
 
-                redshift_type = self._format_redshift_type(self.type_map.get(type_code, type_code), size_str)
+                redshift_type = self._format_redshift_type(self.type_map.get(type_code, type_code), size_str, name)
 
                 field_strs.append(
                     '"{name}" {type}{null_ok}'.format(

--- a/druzhba/postgres.py
+++ b/druzhba/postgres.py
@@ -11,6 +11,7 @@ psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)
 psycopg2.extensions.register_type(psycopg2.extensions.UNICODEARRAY)
 
 ENCODING = "UTF8"
+TYPE_MAP_COLUMN_SECTION = "columns"
 MAX_DECIMAL_PRECISION = 38
 MAX_DECIMAL_SCALE = 37
 
@@ -292,8 +293,8 @@ class PostgreSQLTableConfig(TableConfig):
         return size_str
 
     def _format_redshift_type(self, type_name, size_str, column_name):
-        if column_name in self.type_map['columns']:
-            return self.type_map['columns'][column_name]
+        if  TYPE_MAP_COLUMN_SECTION in self.type_map and column_name in self.type_map[TYPE_MAP_COLUMN_SECTION]:
+            return self.type_map[TYPE_MAP_COLUMN_SECTION][column_name]
         else:
             final_type = "{type}{size}".format(
                     type=type_name, 


### PR DESCRIPTION
This PR allows columns to specify their type, without having to change other similar types. It works like the following example:
```
type_map:
    numeric(19,2): numeric(10,2) // standard type map declaration
    columns:
        exchange_rate: numeric(12,2) // per column type map declaration
```
