### PR TITLE
Log the CREATE TABLE statement at the time it is first determined

### DIFF
--- a/druzhba/table.py
+++ b/druzhba/table.py
@@ -895,9 +895,10 @@ class TableConfig(object):
             try:
                 # Only called to see if it raises, the actual table
                 # will be created later
-                self.query_to_redshift_create_table(
+                create_table = self.query_to_redshift_create_table(
                     self.get_query_sql(), self.destination_table_name
                 )
+                self.logger.info("Will create table using: %s", create_table)
             except NotImplementedError:
                 raise MigrationError(
                     "Automatic table creation was not implemented for "


### PR DESCRIPTION
This is useful for debugging in cases where Druzhba fails later on
in the process (e.g. during the extract query). The CREATE TABLE
statement is already computed and validated prior to running the
extract so there's really no reason not to log it then also.