### PR TITLE
Truncate varchar columns to the maxmimum varchar size

### DIFF
--- a/druzhba/avro.py
+++ b/druzhba/avro.py
@@ -34,7 +34,7 @@ def _avro_format(inp):
 def _redshift_format(inp):
     if isinstance(inp, str):
         # The copy command already has TRUNCATECOLUMNS turned on which will do this for us 
-        # however this protects us from the case where the row size is ridiciously large 
+        # however this protects us from the case where a columns value is ridiciously large 
         # preventing the row from being ingested.
         return inp[:MAX_VARCHAR_SIZE]
     return inp

--- a/druzhba/avro.py
+++ b/druzhba/avro.py
@@ -41,8 +41,8 @@ def _redshift_format(inp):
 
 
 def _format_value(inp):
-    formatted_for_redshift = _redshift_format(inp)
-    return _avro_format(formatted_for_redshift)
+    formatted_for_avro = _avro_format(inp)
+    return _redshift_format(formatted_for_avro)
 
 
 def _format_row(inp):

--- a/druzhba/avro.py
+++ b/druzhba/avro.py
@@ -35,7 +35,7 @@ def _redshift_format(inp):
     if isinstance(inp, str):
         # The copy command already has TRUNCATECOLUMNS turned on which will do this for us 
         # however this protects us from the case where the row size is ridiciously large 
-        # because of one column's value preventing the row from being ingested.
+        # preventing the row from being ingested.
         return inp[:MAX_VARCHAR_SIZE]
     return inp
 

--- a/druzhba/avro.py
+++ b/druzhba/avro.py
@@ -7,6 +7,7 @@ import uuid
 from fastavro._write_py import WRITERS
 from fastavro.write import Writer
 
+MAX_VARCHAR_SIZE = 65535
 
 def _avro_format(inp):
     if isinstance(inp, uuid.UUID):
@@ -30,8 +31,22 @@ def _avro_format(inp):
     return inp
 
 
+def _redshift_format(inp):
+    if isinstance(inp, str):
+        # The copy command already has TRUNCATECOLUMNS turned on which will do this for us 
+        # however this protects us from the case where the row size is ridiciously large 
+        # because of one column's value preventing the row from being ingested.
+        return inp[:MAX_VARCHAR_SIZE]
+    return inp
+
+
+def _format_value(inp):
+    formatted_for_redshift = _redshift_format(inp)
+    return _avro_format(formatted_for_redshift)
+
+
 def _format_row(inp):
-    return {k: _avro_format(v) for k, v in inp.items()}
+    return {k: _format_value(v) for k, v in inp.items()}
 
 
 def write_avro_file(f, results_iter, fields, table, max_size=100 * 1024 ** 2):


### PR DESCRIPTION
This protects us from rows  with a ridiculously large column. 