### PR TITLE
Convert Python byte-string to string for Avro

### DIFF
--- a/druzhba/avro.py
+++ b/druzhba/avro.py
@@ -28,6 +28,8 @@ def _avro_format(inp):
         return (
             unicodedata.normalize("NFKD", inp).encode("ascii", "ignore").decode("ascii")
         )
+    if isinstance(inp, bytes):
+        return inp.decode(encoding="utf-8")
     return inp
 
 


### PR DESCRIPTION
Fixes a failing conversion from Python byte-string when the Avro field-type is [null, string]