### PR TITLE
Create the ability to override the database name across the database

### DIFF
--- a/druzhba/db.py
+++ b/druzhba/db.py
@@ -43,6 +43,11 @@ class DatabaseConfig(object):
     db_template_data : dict, optional
         parameters to interpolate into SQL queries, if this is
         a SQL-defined table.
+    override_db_name : str, optional
+        override database name to use in the index tracking table instead of
+        the actual database name. This allows tracking multiple databases or
+        environments under a common name for index purposes. If the override_db_name
+        is set on the table the override_db_name on the database is ignored.
 
     Attributes
     ----------
@@ -62,6 +67,7 @@ class DatabaseConfig(object):
         connection_string_env=None,
         object_schema_name=None,
         db_template_data=None,
+        override_db_name=None
     ):
         self.database_alias = database_alias
         self.database_type = database_type
@@ -70,6 +76,7 @@ class DatabaseConfig(object):
         self._connection_string_env = connection_string_env
         self._object_schema_name = object_schema_name
         self._db_template_data = db_template_data
+        self._override_db_name = override_db_name
 
         if self.database_type == "mysql":
             self._table_conf_cls = MySQLTableConfig
@@ -85,6 +92,8 @@ class DatabaseConfig(object):
             raise ValueError(msg)
 
     def get_table_config(self, table_params, index_schema, index_table, monitor_tables_config):
+        if table_params.get('override_db_name') is None and self._override_db_name is not None:
+            table_params['override_db_name'] = self._override_db_name
         return self._table_conf_cls(
             self.database_alias,
             self.get_connection_params(),

--- a/druzhba/main.py
+++ b/druzhba/main.py
@@ -278,6 +278,7 @@ def set_up_database(
         ),
         object_schema_name=db_template_data.get("object_schema_name"),
         db_template_data=db_template_data,
+        override_db_name=dbconfig.get("override_db_name")
     )
 
     return db, dbconfig

--- a/druzhba/main.py
+++ b/druzhba/main.py
@@ -278,7 +278,7 @@ def set_up_database(
         ),
         object_schema_name=db_template_data.get("object_schema_name"),
         db_template_data=db_template_data,
-        override_db_name=dbconfig.get("override_db_name")
+        override_db_name=db_config_override.get("override_db_name")
     )
 
     return db, dbconfig

--- a/test/unit/test_db.py
+++ b/test/unit/test_db.py
@@ -56,6 +56,25 @@ class DbTest(unittest.TestCase):
             params.additional, {"sslmode": "disable", "connect_timeout": "60"}
         )
 
+    def test_database_override(self):
+        config = DatabaseConfig(
+            "test_db",
+            "mysql",
+            ("postgresql://test_user:test_password@test-db.prod:5439/" "test_db_name"),
+            override_db_name="overridden_database_name"
+        )
+
+        self.assertIsNotNone(config)
+        table_config = {
+            "database_alias": "alias",
+            "destination_table_name": "table",
+            "destination_schema_name": "schema",
+            "source_table_name": "source",
+            "index_column": "id",
+        }
+        table_config = config.get_table_config(table_config, "index_schema", "index_table", None)
+        self.assertEqual(table_config.override_db_name, "overridden_database_name")
+
 
 class ConnectionParamsTest(unittest.TestCase):
     def test_bad_connection_params(self):

--- a/test/unit/test_db.py
+++ b/test/unit/test_db.py
@@ -66,7 +66,6 @@ class DbTest(unittest.TestCase):
 
         self.assertIsNotNone(config)
         table_config = {
-            "database_alias": "alias",
             "destination_table_name": "table",
             "destination_schema_name": "schema",
             "source_table_name": "source",


### PR DESCRIPTION
Add a config param to allow overwriting of the db name in the tracking table across the database